### PR TITLE
fix encoding in windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import find_packages
 from setuptools import setup
+import codecs
 
 REQUIRED_PACKAGES = ['numpy==1.13', 'ConfigArgParse>=0.12', 'tensorflow']
 
 def readme():
-	with open('README.md') as f:
+	with codecs.open('README.md','r',encoding='utf-8') as f:
 		return f.read()
 
 setup(name='cutkum',


### PR DESCRIPTION
```
Collecting cutkum
  Downloading cutkum-1.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\WANNAP~1\AppData\Local\Temp\pip-build-0dxo1kux\cutkum\setup.py", line 13, in <module>
        long_description=readme(),
      File "C:\Users\WANNAP~1\AppData\Local\Temp\pip-build-0dxo1kux\cutkum\setup.py", line 8, in readme
        return f.read()
      File "C:\Users\wannaphong\Anaconda3\Lib\encodings\cp874.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x84 in position 13: character maps to <undefined>

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\WANNAP~1\AppData\Local\Temp\pip-build-0dxo1kux\cutkum\
```